### PR TITLE
Checkout sources before running local action to clena up releases

### DIFF
--- a/.github/workflows/clean-up-pr.yml
+++ b/.github/workflows/clean-up-pr.yml
@@ -11,6 +11,7 @@ jobs:
     name: Delete Release Candidates
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Delete release candidates
         uses: ./
         with:


### PR DESCRIPTION
This PR checks out the repo sources before trying to run a local action.