### PR TITLE
Fix release deletion and add new inputs

### DIFF
--- a/.github/workflows/clean-up-pr.yml
+++ b/.github/workflows/clean-up-pr.yml
@@ -16,4 +16,5 @@ jobs:
       - name: Delete release candidates
         uses: ./
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           release-identifier: '-pr${{ github.event.number }}-rc'

--- a/.github/workflows/clean-up-pr.yml
+++ b/.github/workflows/clean-up-pr.yml
@@ -3,12 +3,13 @@ name: Delete Release Candidates
 
 on:
   pull_request:
-    types: [ closed ]
+    types: [ closed, labeled ]
 
 
 jobs:
   delete-release-candidates:
     name: Delete Release Candidates
+    if: github.event.action == 'closed' || github.event.label.name == 'delete-releases'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This action is used to automate the removal of release candidates that are typic
 | ecr-name              | The name of an ECR where to look for container images tagged with the releases we are deleting. The name is not the full URL, it is just the last bit of the URL. | false    |                |
 | s3-bucket             | The name of a S3 bucket where to look for artefacts tagged with the releases we are deleting.                                                                     | false    |                |
 | s3-object-key-prefix  | The S3 object key prefix used to look for artefacts tagged with the releases we are deleting.                                                                     | false    |                |
+| github-token          | The github token used to delete the releases and tags.                                                                                                            | true     |                |
 | aws-access-key-id     | The AWS access key ID providing access to delete artefacts from either or both ECR and S3 Bucket.                                                                 | false    |                |
 | aws-secret-access-key | The runtimes where to deploy the release.                                                                                                                         | false    |                |
 | aws-region            | The AWS region.                                                                                                                                                   | false    | 'eu-central-1' |
@@ -53,6 +54,7 @@ jobs:
       - uses: GRESB/action-delete-release-candidates
         with:
           release-identifier: '-pr${{ github.event.number }}-rc'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Remove GitHub Releases and S3 Artefacts
@@ -79,6 +81,7 @@ jobs:
           release-identifier: '-pr${{ github.event.number }}-rc'
           s3-bucket: 'my-bucket'
           s3-object-key-prefix: 'my-app/packages'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           aws-access-key-id: ${{ secrets.aws-access-key-id }}
           aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
 ```
@@ -106,6 +109,7 @@ jobs:
         with:
           release-identifier: '-pr${{ github.event.number }}-rc'
           ecr-name: 'my-app-registry'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           aws-access-key-id: ${{ secrets.aws-access-key-id }}
           aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
 ```

--- a/README.md
+++ b/README.md
@@ -10,15 +10,16 @@ This action is used to automate the removal of release candidates that are typic
 
 ## Inputs
 
-| Input                 | Description                                                                                                                                                                                                      | Required | Default        |
-|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|----------------|
-| release-identifier    | A string that will be used to identify the releases to be deleted (eg. "pr1234").                                                                                                                                | true     |                |
-| ecr-name              | The name of an ECR where to look for container images tagged with the releases we are deleting. The name is not the full URL, it is just the last bit of the URL.                                                | false    |                |
-| s3-bucket             | The name of a S3 bucket where to look for artefacts tagged with the releases we are deleting.                                                                                                                    | false    |                |
-| s3-object-key-prefix  | The S3 object key prefix used to look for artefacts tagged with the releases we are deleting.                                                                                                                    | false    |                |
-| aws-access-key-id     | The AWS access key ID providing access to delete artefacts from either or both ECR and S3 Bucket.                                                                                                                | false    |                |
-| aws-secret-access-key | The runtimes where to deploy the release.                                                                                                                                                                        | false    |                |
-| aws-region            | The AWS region.                                                                                                                                                                                                  | false    | 'eu-central-1' |
+| Input                 | Description                                                                                                                                                       | Required | Default        |
+|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|----------------|
+| release-identifier    | A string that will be used to identify the releases to be deleted (eg. "pr1234").                                                                                 | true     |                |
+| keep-latest-count     | The number of matches releases to keep, ordered from latest to oldest.                                                                                            | true     | '0'            |
+| ecr-name              | The name of an ECR where to look for container images tagged with the releases we are deleting. The name is not the full URL, it is just the last bit of the URL. | false    |                |
+| s3-bucket             | The name of a S3 bucket where to look for artefacts tagged with the releases we are deleting.                                                                     | false    |                |
+| s3-object-key-prefix  | The S3 object key prefix used to look for artefacts tagged with the releases we are deleting.                                                                     | false    |                |
+| aws-access-key-id     | The AWS access key ID providing access to delete artefacts from either or both ECR and S3 Bucket.                                                                 | false    |                |
+| aws-secret-access-key | The runtimes where to deploy the release.                                                                                                                         | false    |                |
+| aws-region            | The AWS region.                                                                                                                                                   | false    | 'eu-central-1' |
 
 ## Outputs
 

--- a/action.yaml
+++ b/action.yaml
@@ -17,6 +17,9 @@ inputs:
   s3-object-key-prefix:
     description: 'The S3 object key prefix used to look for artefacts tagged with the releases we are deleting.'
     required: false
+  github-token:
+    description: 'The github token used to delete the releases and tags.'
+    required: true
   aws-access-key-id:
     description: 'The AWS access key ID providing access to delete artefacts from either or both ECR and S3 Bucket.'
     required: false
@@ -44,6 +47,7 @@ runs:
         include_draft: true
         delete_tags: true
         keep_latest_count: ${{ inputs.keep-latest-count }}
+        github_token: ${{ inputs.github-token }}
     - name: Authenticate to AWS
       uses: aws-actions/configure-aws-credentials@v1
       if: always() && inputs.aws-access-key-id && inputs.aws-secret-access-key

--- a/action.yaml
+++ b/action.yaml
@@ -32,7 +32,7 @@ runs:
   steps:
     - name: Delete GitHub release candidates
       id: delete-github
-      uses: wow-actions/delete-stale-releases@v1.2.3
+      uses: wow-actions/delete-stale-releases@v1.2.1 # later releases are broken https://github.com/wow-actions/delete-stale-releases/issues/3
       with:
         key: name
         include: '*${{ inputs.release-identifier }}*'

--- a/action.yaml
+++ b/action.yaml
@@ -4,6 +4,10 @@ inputs:
   release-identifier:
     description: 'A string that will be used to identify the releases to be deleted (eg. "pr1234").'
     required: true
+  keep-latest-count:
+    description: 'The number of matches releases to keep, ordered from latest to oldest.'
+    required: true
+    default: '0'
   ecr-name:
     description: 'The name of an ECR where to look for container images tagged with the releases we are deleting. The name is not the full URL, it is just the last bit of the URL.'
     required: false
@@ -39,6 +43,7 @@ runs:
         include_prerelease: true
         include_draft: true
         delete_tags: true
+        keep_latest_count: ${{ inputs.keep-latest-count }}
     - name: Authenticate to AWS
       uses: aws-actions/configure-aws-credentials@v1
       if: always() && inputs.aws-access-key-id && inputs.aws-secret-access-key


### PR DESCRIPTION
This PR downgrades the delete-stale-releases action to a version that is not affected by [this bug](https://github.com/wow-actions/delete-stale-releases/issues/3). The PR also introduces two new inputs:
- `github-token`: to provide a token for deleting releases and tags;
- `keep-latest-count`: to control how many (if any) matched release should be kept.
