### PR TITLE
Prevent unwanted deletion of releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This action is used to automate the removal of release candidates that are typic
 | aws-access-key-id     | The AWS access key ID providing access to delete artefacts from either or both ECR and S3 Bucket.                                                                 | false    |                |
 | aws-secret-access-key | The runtimes where to deploy the release.                                                                                                                         | false    |                |
 | aws-region            | The AWS region.                                                                                                                                                   | false    | 'eu-central-1' |
+| dry-run               | Whether to only print the artefacts that are matched for deletion instead of deleting them.                                                                       | true     | 'true'         |
 
 ## Outputs
 

--- a/action.yaml
+++ b/action.yaml
@@ -30,6 +30,10 @@ inputs:
     description: 'The AWS region.'
     required: false
     default: 'eu-central-1'
+  dry-run:
+    description: 'Whether to only print the artefacts that are matched for deletion instead of deleting them.'
+    required: true
+    default: 'true'
 outputs:
   releases:
     description: 'The releases that were identified and deleted.'
@@ -74,13 +78,18 @@ runs:
           while read package; do
             echo "==> Deleting S3 package ${package}";
             s3_url="${s3_app_url}/${package}"
-            aws s3 rm "${s3_url}"
+            if [[ "${dry_run}" == "false" ]]; then
+              aws s3 rm "${s3_url}"
+            else
+              echo "==> [Dry Run] aws s3 rm ${s3_url}"
+            fi
           done <<<"${packages}"
         fi
       env:
         bucket_name: ${{ inputs.s3-bucket }}
         object_key_prefix: ${{ inputs.s3-object-key-prefix }}
         release_identifier: ${{ inputs.release-identifier }}
+        dry_run: ${{ inputs.dry-run }}
     - name: Delete ECR release candidates
       if: always() && inputs.release-identifier && inputs.ecr-name
       shell: bash
@@ -98,9 +107,14 @@ runs:
           echo "==> Deleting images from ECR: \n${image_tags}"
           while read tag; do
             echo "==> Deleting ECR tag ${tag}";
-            aws ecr batch-delete-image --repository-name "${ecr_name}" --image-ids "imageTag=${tag}"
+            if [[ "${dry_run}" == "false" ]]; then 
+              aws ecr batch-delete-image --repository-name "${ecr_name}" --image-ids "imageTag=${tag}"
+            else
+              echo "==> [Dry Run] aws ecr batch-delete-image --repository-name ${ecr_name} --image-ids imageTag=${tag}"
+            fi
           done <<<"${image_tags}"
         fi
       env:
         ecr_name: ${{ inputs.ecr-name }}
         release_identifier: ${{ inputs.release-identifier }}
+        dry_run: ${{ inputs.dry-run }}

--- a/action.yaml
+++ b/action.yaml
@@ -84,6 +84,8 @@ runs:
               echo "==> [Dry Run] aws s3 rm ${s3_url}"
             fi
           done <<<"${packages}"
+        else
+          echo "==> No packages found in '${s3_app_url}' using filter '${release_identifier}'"
         fi
       env:
         bucket_name: ${{ inputs.s3-bucket }}
@@ -113,6 +115,8 @@ runs:
               echo "==> [Dry Run] aws ecr batch-delete-image --repository-name ${ecr_name} --image-ids imageTag=${tag}"
             fi
           done <<<"${image_tags}"
+        else
+          echo "==> No container images found in ECR '${ecr_name}' using filter '${release_identifier}'"
         fi
       env:
         ecr_name: ${{ inputs.ecr-name }}

--- a/action.yaml
+++ b/action.yaml
@@ -74,7 +74,7 @@ runs:
         s3_app_url="s3://${bucket_name}/${object_key_prefix}"
         packages="$( aws s3 ls "${s3_app_url}/" | grep "${release_identifier}" | tr -s ' ' | cut -d ' ' -f 4 || true )"
         if [[ -n "${packages}" ]]; then
-          echo "==> Deleting packages from S3: \n${packages}"
+          echo -e "==> Deleting packages from S3: \n${packages}"
           while read package; do
             echo "==> Deleting S3 package ${package}";
             s3_url="${s3_app_url}/${package}"
@@ -104,7 +104,7 @@ runs:
           | jq --arg tagFilter "^.*${release_identifier}.*$" -r '.imageIds[] .imageTag | select(. | test($tagFilter))' \
         )"
         if [[ -n "${image_tags}" ]]; then
-          echo "==> Deleting images from ECR: \n${image_tags}"
+          echo -e "==> Deleting images from ECR: \n${image_tags}"
           while read tag; do
             echo "==> Deleting ECR tag ${tag}";
             if [[ "${dry_run}" == "false" ]]; then 

--- a/action.yaml
+++ b/action.yaml
@@ -39,6 +39,7 @@ runs:
   steps:
     - name: Delete GitHub release candidates
       id: delete-github
+      if: inputs.release-identifier
       uses: wow-actions/delete-stale-releases@v1.2.1 # later releases are broken https://github.com/wow-actions/delete-stale-releases/issues/3
       with:
         key: name
@@ -50,7 +51,7 @@ runs:
         github_token: ${{ inputs.github-token }}
     - name: Authenticate to AWS
       uses: aws-actions/configure-aws-credentials@v1
-      if: always() && inputs.aws-access-key-id && inputs.aws-secret-access-key
+      if: always() && inputs.release-identifier && inputs.aws-access-key-id && inputs.aws-secret-access-key
       id: aws-credentials
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
@@ -58,9 +59,14 @@ runs:
         aws-region: ${{ inputs.aws-region }}
         mask-aws-account-id: false
     - name: Delete Artefacts in S3
-      if: always() && inputs.s3-bucket
+      if: always() && inputs.release-identifier && inputs.s3-bucket && inputs.s3-object-key-prefix
       shell: bash
       run: |
+        if [[ "${release_identifier}" == "" ]]; then
+          echo "==# Skipping S3 artefact deletion: no release identifier provided";
+          exit 1
+        fi
+
         s3_app_url="s3://${bucket_name}/${object_key_prefix}"
         packages="$( aws s3 ls "${s3_app_url}/" | grep "${release_identifier}" | tr -s ' ' | cut -d ' ' -f 4 || true )"
         if [[ -n "${packages}" ]]; then
@@ -76,9 +82,14 @@ runs:
         object_key_prefix: ${{ inputs.s3-object-key-prefix }}
         release_identifier: ${{ inputs.release-identifier }}
     - name: Delete ECR release candidates
-      if: always() && inputs.ecr-name
+      if: always() && inputs.release-identifier && inputs.ecr-name
       shell: bash
       run: |
+        if [[ "${release_identifier}" == "" ]]; then
+          echo "==# Skipping ECR image deletion: no release identifier provided";
+          exit 1
+        fi
+
         image_tags="$( \
           aws ecr list-images --repository-name "${ecr_name}" \
           | jq --arg tagFilter "^.*${release_identifier}.*$" -r '.imageIds[] .imageTag | select(. | test($tagFilter))' \

--- a/action.yaml
+++ b/action.yaml
@@ -47,7 +47,7 @@ runs:
       uses: wow-actions/delete-stale-releases@v1.2.1 # later releases are broken https://github.com/wow-actions/delete-stale-releases/issues/3
       with:
         key: name
-        include: ${{ inputs.release-identifier }}
+        include: '*${{ inputs.release-identifier }}*'
         include_prerelease: true
         include_draft: true
         delete_tags: true

--- a/action.yaml
+++ b/action.yaml
@@ -54,7 +54,7 @@ runs:
         keep_latest_count: ${{ inputs.keep-latest-count }}
         github_token: ${{ inputs.github-token }}
     - name: Authenticate to AWS
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       if: always() && inputs.release-identifier && inputs.aws-access-key-id && inputs.aws-secret-access-key
       id: aws-credentials
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -47,7 +47,7 @@ runs:
       uses: wow-actions/delete-stale-releases@v1.2.1 # later releases are broken https://github.com/wow-actions/delete-stale-releases/issues/3
       with:
         key: name
-        include: '*${{ inputs.release-identifier }}*'
+        include: ${{ inputs.release-identifier }}
         include_prerelease: true
         include_draft: true
         delete_tags: true


### PR DESCRIPTION
Although the `release-identifier` is required, the action executes without it anyway. When executing without it the action has the potential to delete all released artefacts. This PR introduces guards to prevent executing the steps if the `release-identifier` is not present. In addition the PR also adds a new input `dry-run` to allow listing the artefacts that would be deleted whiteout actually deleting them.