### PR TITLE
untagged images in ecr

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -103,7 +103,7 @@ runs:
 
         image_tags="$( \
           aws ecr list-images --repository-name "${ecr_name}" \
-          | jq --arg tagFilter "^.*${release_identifier}.*$" -r '.imageIds[] .imageTag | select(. | test($tagFilter))' \
+          | jq --arg tagFilter "^.*${release_identifier}.*$" -r '.imageIds[] .imageTag | select(. !=null ) | select(. | test($tagFilter))' \
         )"
         if [[ -n "${image_tags}" ]]; then
           echo -e "==> Deleting images from ECR: \n${image_tags}"


### PR DESCRIPTION
It is possible for ecr to have untagged (null image tag) images. However when we try to delete it the action fails. This PR adds a filter for null image tags.