### PR TITLE
Add new input for github package type

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,21 @@ This action is used to automate the removal of release candidates that are typic
 
 ## Inputs
 
-| Input                 | Description                                                                                                                                                       | Required | Default        |
-|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|----------------|
-| release-identifier    | A string that will be used to identify the releases to be deleted (eg. "pr1234").                                                                                 | true     |                |
-| keep-latest-count     | The number of matches releases to keep, ordered from latest to oldest.                                                                                            | true     | '0'            |
-| ecr-name              | The name of an ECR where to look for container images tagged with the releases we are deleting. The name is not the full URL, it is just the last bit of the URL. | false    |                |
-| s3-bucket             | The name of a S3 bucket where to look for artefacts tagged with the releases we are deleting.                                                                     | false    |                |
-| s3-object-key-prefix  | The S3 object key prefix used to look for artefacts tagged with the releases we are deleting.                                                                     | false    |                |
-| github-package-name   | The name of the GitHub packages to delete.                                                                                                                        | false    |                |
-| github-token          | The github token used to delete the releases and tags.                                                                                                            | true     |                |
-| aws-role-arn          | The AWS IAM role providing access to delete artefacts from either or both ECR and S3 Bucket.                                                                      | false    |                |
-| aws-access-key-id     | The AWS access key ID providing access to delete artefacts from either or both ECR and S3 Bucket.                                                                 | false    |                |
-| aws-secret-access-key | The runtimes where to deploy the release.                                                                                                                         | false    |                |
-| aws-region            | The AWS region.                                                                                                                                                   | false    | 'eu-central-1' |
-| dry-run               | Whether to only print the artefacts that are matched for deletion instead of deleting them.                                                                       | true     | 'true'         |
+| Input                 | Description                                                                                                                                                                                                  | Required | Default        |
+|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|----------------|
+| release-identifier    | A string that will be used to identify the releases to be deleted (eg. "pr1234").                                                                                                                            | true     |                |
+| keep-latest-count     | The number of matches releases to keep, ordered from latest to oldest.                                                                                                                                       | true     | '0'            |
+| ecr-name              | The name of an ECR where to look for container images tagged with the releases we are deleting. The name is not the full URL, it is just the last bit of the URL.                                            | false    |                |
+| s3-bucket             | The name of a S3 bucket where to look for artefacts tagged with the releases we are deleting.                                                                                                                | false    |                |
+| s3-object-key-prefix  | The S3 object key prefix used to look for artefacts tagged with the releases we are deleting.                                                                                                                | false    |                |
+| github-package-name   | The name of the GitHub packages to delete.                                                                                                                                                                   | false    |                |
+| github-package-type   | The type of the GitHub packages to delete. See package_type under query parameters at https://docs.github.com/en/rest/packages/packages?apiVersion=2022-11-28#list-packages-for-an-organization--parameters. | false    | 'maven'        |
+| github-token          | The github token used to delete the releases and tags.                                                                                                                                                       | true     |                |
+| aws-role-arn          | The AWS IAM role providing access to delete artefacts from either or both ECR and S3 Bucket.                                                                                                                 | false    |                |
+| aws-access-key-id     | The AWS access key ID providing access to delete artefacts from either or both ECR and S3 Bucket.                                                                                                            | false    |                |
+| aws-secret-access-key | The runtimes where to deploy the release.                                                                                                                                                                    | false    |                |
+| aws-region            | The AWS region.                                                                                                                                                                                              | false    | 'eu-central-1' |
+| dry-run               | Whether to only print the artefacts that are matched for deletion instead of deleting them.                                                                                                                  | true     | 'true'         |
 
 ## Outputs
 

--- a/action.yaml
+++ b/action.yaml
@@ -20,6 +20,10 @@ inputs:
   github-package-name:
     description: 'The name of the GitHub packages to delete.'
     required: false
+  github-package-type:
+    description: 'The type of the GitHub packages to delete. See package_type under query parameters at https://docs.github.com/en/rest/packages/packages?apiVersion=2022-11-28#list-packages-for-an-organization--parameters'
+    required: false
+    default: 'maven'
   github-token:
     description: 'The github token used to delete the releases and tags.'
     required: true
@@ -140,12 +144,13 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.github-token }}
         release_identifier: ${{ inputs.release-identifier }}
+        package_type: ${{ inputs.github-package-type }}
       run: |
         version_ids=$( \
         gh api \
           -H "Accept: application/vnd.github+json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          /orgs/GRESB/packages/maven/${package_name}/versions \
+          /orgs/GRESB/packages/${package_type}/${package_name}/versions \
           |  jq -r --arg identifier "${release_identifier}" 'map(select(.name | contains($identifier))) | map(.id) | join(", ")' \
         )
 
@@ -159,6 +164,6 @@ runs:
       with:
         package-version-ids: ${{ steps.get-package-details.outputs.version-ids }}
         package-name: ${{ inputs.github-package-name }}
-        package-type: 'maven'
+        package-type: ${{ inputs.github-package-type }}
       env:
         GH_TOKEN: ${{ inputs.github-token }}


### PR DESCRIPTION
This PR adds a new input for the action to specify the GitHub package type. With this input we can delete packages of any type from the GitHub registry.