### PR TITLE
Add the possibility to delete S3 Folders

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -87,7 +87,7 @@ runs:
         fi
 
         s3_app_url="s3://${bucket_name}/${object_key_prefix}"
-        packages="$( aws s3 ls "${s3_app_url}/" | grep -- "${release_identifier}" | tr -s ' ' | cut -d ' ' -f 4 || true )"
+        packages="$( aws s3 ls "${s3_app_url}/" | grep -- "${release_identifier}" | tr -s ' ' | awk '{print $NF}' || true )"
         if [[ -n "${packages}" ]]; then
           echo -e "==> Deleting packages from S3: \n${packages}"
           while read package; do


### PR DESCRIPTION
In repositories like the [template-app-sveltekit-micronaut](https://github.com/GRESB/template-app-sveltekit-micronaut) we are pushing a folder to an S3 bucket which contains our static website, when deleting the release candidates for this type of repositories we need to delete the whole folder that was uploaded and not only a file that matches the release identifier.
To achieve that I replaced the cut logic from the `Delete Artefacts in S3` step to use the `awk` command.